### PR TITLE
Improve iOS Firebase Messaging setup

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,13 +1,40 @@
 import Flutter
 import UIKit
+import Firebase
+import FirebaseMessaging
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, UNUserNotificationCenterDelegate, MessagingDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    FirebaseApp.configure()
+    UNUserNotificationCenter.current().delegate = self
+    Messaging.messaging().delegate = self
     GeneratedPluginRegistrant.register(with: self)
+    application.registerForRemoteNotifications()
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  override func application(
+    _ application: UIApplication,
+    didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+  ) {
+    Messaging.messaging().apnsToken = deviceToken
+    super.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+  }
+
+  func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+    if let token = fcmToken {
+      NSLog("FCM registration token: \(token)")
+    }
+  }
+
+  override func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification
+  ) async -> UNNotificationPresentationOptions {
+    return [.badge, .sound, .banner]
   }
 }

--- a/lib/core/service/firebase_auth_service.dart
+++ b/lib/core/service/firebase_auth_service.dart
@@ -33,7 +33,8 @@ class FirebaseAuthService {
       appLog('FirebaseAuthService: Created user -> ${credential.user?.uid}');
       return credential.user!;
     } on FirebaseAuthException catch (e) {
-      appLog('Error in FirebaseAuthService.createUserWithEmailAndPassword: ${e.code}');
+      appLog(
+          'Error in FirebaseAuthService.createUserWithEmailAndPassword: ${e.code}');
       throw CustomFirebaseException.getFirebaseAuthException(e.code);
     } catch (e) {
       appLog('Unknown error in createUserWithEmailAndPassword: $e');
@@ -53,7 +54,8 @@ class FirebaseAuthService {
       );
       return credential.user!;
     } on FirebaseAuthException catch (e) {
-      appLog('Error in FirebaseAuthService.signInWithEmailAndPassword: ${e.code}');
+      appLog(
+          'Error in FirebaseAuthService.signInWithEmailAndPassword: ${e.code}');
       throw CustomFirebaseException.getFirebaseAuthException(e.code);
     } catch (e) {
       appLog('Unknown error in signInWithEmailAndPassword: $e');
@@ -157,6 +159,10 @@ class FirebaseAuthService {
         ],
         nonce: nonce,
       );
+      appLog(
+        'Apple credential received: user=${appleCredential.userIdentifier}, '
+        'email=${appleCredential.email}, state=${appleCredential.state}',
+      );
 
       final oauthCredential = OAuthProvider("apple.com").credential(
         idToken: appleCredential.identityToken,
@@ -167,10 +173,12 @@ class FirebaseAuthService {
           await FirebaseAuth.instance.signInWithCredential(oauthCredential);
       return userCred.user!;
     } on FirebaseAuthException catch (e) {
-      appLog('Error in FirebaseAuthService.signInWithApple: ${e.code}');
+      appLog(
+        'Error in FirebaseAuthService.signInWithApple: ${e.code} ${e.message}',
+      );
       throw CustomFirebaseException.getFirebaseAuthException(e.code);
-    } catch (e) {
-      appLog('Unknown error in signInWithApple: $e');
+    } catch (e, s) {
+      appLog('Unknown error in signInWithApple: $e', stackTrace: s);
       throw CustomException(S.current.SomethingWentWrong);
     }
   }

--- a/lib/core/utils/firebase_utils.dart
+++ b/lib/core/utils/firebase_utils.dart
@@ -22,8 +22,8 @@ Future<String?> initFirebaseMessaging({
         sound: true,
       );
     } else if (Platform.isAndroid) {
-      final androidImpl = flutterLocalNotificationsPlugin
-          .resolvePlatformSpecificImplementation<
+      final androidImpl =
+          flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
               AndroidFlutterLocalNotificationsPlugin>();
       await androidImpl?.requestNotificationsPermission();
     } else {
@@ -37,7 +37,10 @@ Future<String?> initFirebaseMessaging({
     for (var i = 0; i < attempts; i++) {
       try {
         final apns = await FirebaseMessaging.instance.getAPNSToken();
-        if (apns != null) break;
+        if (apns != null) {
+          appLog('APNS token retrieved: $apns');
+          break;
+        }
       } on FirebaseException catch (e) {
         if (e.code != 'apns-token-not-set') {
           appLog('Error fetching APNS token: $e');
@@ -54,7 +57,10 @@ Future<String?> initFirebaseMessaging({
   for (var i = 0; i < attempts; i++) {
     try {
       final token = await FirebaseMessaging.instance.getToken();
-      if (token != null) return token;
+      if (token != null) {
+        appLog('FCM token retrieved: $token');
+        return token;
+      }
     } on FirebaseException catch (e) {
       if (e.code == 'apns-token-not-set') {
         await Future.delayed(retryDelay);
@@ -67,6 +73,6 @@ Future<String?> initFirebaseMessaging({
       return null;
     }
   }
-
+  appLog('Failed to obtain FCM token after $attempts attempts');
   return null;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ import 'package:deals/features/notifications/data/data_source/notification_local
 import 'package:deals/features/notifications/presentation/manager/cubits/notification_cubit/notifications_cubit.dart';
 import 'package:deals/firebase_options.dart';
 import 'package:deals/generated/l10n.dart';
+import 'package:deals/core/utils/firebase_utils.dart';
 
 // 1) Local notifications plugin
 final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
@@ -60,8 +61,8 @@ Future<void> initializeLocalNotifications() async {
       AndroidInitializationSettings('@mipmap/ic_launcher');
 
   // iOS / Darwin settings (v10+ uses DarwinInitializationSettings):
-  const DarwinInitializationSettings
-  iosInitSettings = DarwinInitializationSettings(
+  const DarwinInitializationSettings iosInitSettings =
+      DarwinInitializationSettings(
     requestAlertPermission: false,
     requestBadgePermission: false,
     requestSoundPermission: false,
@@ -154,8 +155,8 @@ Future<void> requestNotificationPermissions() async {
       sound: true,
     );
   } else if (Platform.isAndroid) {
-    final androidImpl = flutterLocalNotificationsPlugin
-        .resolvePlatformSpecificImplementation<
+    final androidImpl =
+        flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
             AndroidFlutterLocalNotificationsPlugin>();
     await androidImpl?.requestNotificationsPermission();
   }
@@ -188,10 +189,15 @@ Future<void> main() async {
   await initializeLocalNotifications();
   await requestNotificationPermissions();
   _attachFcmListener();
+  if (!kReleaseMode) {
+    final token = await initFirebaseMessaging();
+    appLog('Initial FCM token: $token');
+  }
 
   Future<void> runner() async {
     runApp(_buildApp());
   }
+
   if (kReleaseMode) {
     await _initSentry(runner);
   } else {


### PR DESCRIPTION
## Summary
- configure Firebase Messaging in `AppDelegate`
- register for remote notifications and forward tokens to FCM
- handle foreground presentation options

## Testing
- `./flutter/bin/dart format lib/core/service/firebase_auth_service.dart lib/core/utils/firebase_utils.dart lib/main.dart`
- `./flutter/bin/flutter analyze --no-pub` *(11467 issues found)*
- `./flutter/bin/flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6862cd0210f0832e8aa806913fbdf76a