### PR TITLE
Fix iOS compile error in AppDelegate

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -45,7 +45,7 @@ class AppDelegate: FlutterAppDelegate, MessagingDelegate {
 
   // MARK: - Foreground notification display (classic method)
   // This is the old signature—no async—so it works on iOS 13+
-  func userNotificationCenter(
+  override func userNotificationCenter(
     _ center: UNUserNotificationCenter,
     willPresent notification: UNNotification,
     withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void


### PR DESCRIPTION
## Summary
- fix `userNotificationCenter` signature to override base implementation

## Testing
- `./flutter/bin/flutter analyze`
- `./flutter/bin/flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6863aabb01c4832e9cccf9343bad2624