### PR TITLE
Handle initial push notification

### DIFF
--- a/lib/core/utils/firebase_utils.dart
+++ b/lib/core/utils/firebase_utils.dart
@@ -1,84 +1,70 @@
-import 'dart:io';
 import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:deals/main.dart'; // for flutterLocalNotificationsPlugin
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:firebase_core/firebase_core.dart';
 
 import 'logger.dart';
 
-/// Initializes Firebase Messaging by requesting the user's permission and
-/// ensuring the APNS token is available on iOS before fetching the FCM token.
-///
-/// Returns the FCM token if available, or `null` if it could not be retrieved.
-Future<String?> initFirebaseMessaging({
-  int attempts = 3,
-  Duration retryDelay = const Duration(seconds: 1),
-}) async {
-  appLog('initFirebaseMessaging: requesting notification permissions');
+final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
+    FlutterLocalNotificationsPlugin();
+
+const AndroidNotificationChannel notificationChannel = AndroidNotificationChannel(
+  'high_importance_channel',
+  'High Importance Notifications',
+  description: 'This channel is used for important notifications.',
+  importance: Importance.high,
+);
+
+Future<void> initializeNotifications() async {
+  const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
+  const iosInit = DarwinInitializationSettings();
+  const initSettings = InitializationSettings(android: androidInit, iOS: iosInit);
+
+  await flutterLocalNotificationsPlugin.initialize(initSettings);
+
+  await flutterLocalNotificationsPlugin
+      .resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin>()
+      ?.createNotificationChannel(notificationChannel);
+
+  await FirebaseMessaging.instance.setForegroundNotificationPresentationOptions(
+    alert: true,
+    badge: true,
+    sound: true,
+  );
+}
+
+Future<NotificationSettings> requestPushPermission() {
+  return FirebaseMessaging.instance.requestPermission();
+}
+
+Future<String?> getFcmToken() async {
   try {
-    if (Platform.isIOS || Platform.isMacOS) {
-      await FirebaseMessaging.instance.requestPermission(
-        alert: true,
-        badge: true,
-        sound: true,
-      );
-      appLog('initFirebaseMessaging: permission request sent for iOS/macOS');
-    } else if (Platform.isAndroid) {
-      final androidImpl =
-          flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
-              AndroidFlutterLocalNotificationsPlugin>();
-      await androidImpl?.requestNotificationsPermission();
-      appLog('initFirebaseMessaging: permission request sent for Android');
-    } else {
-      await FirebaseMessaging.instance.requestPermission();
-      appLog('initFirebaseMessaging: generic permission request sent');
-    }
+    final token = await FirebaseMessaging.instance.getToken();
+    appLog('FCM token -> $token');
+    return token;
   } catch (e) {
-    appLog('Error requesting notification permissions: $e');
+    appLog('Error getting FCM token: $e');
+    return null;
   }
+}
 
-  if (Platform.isIOS || Platform.isMacOS) {
-    for (var i = 0; i < attempts; i++) {
-      try {
-        appLog('initFirebaseMessaging: fetching APNS token (attempt $i)');
-        final apns = await FirebaseMessaging.instance.getAPNSToken();
-        if (apns != null) {
-          appLog('APNS token retrieved: $apns');
-          break;
-        }
-      } on FirebaseException catch (e) {
-        if (e.code != 'apns-token-not-set') {
-          appLog('Error fetching APNS token: $e');
-          break;
-        }
-      } catch (e) {
-        appLog('Unexpected error getting APNS token: $e');
-        break;
-      }
-      await Future.delayed(retryDelay);
-    }
-  }
+Future<void> showFlutterNotification(RemoteMessage message) async {
+  final notification = message.notification;
+  if (notification == null) return;
 
-  for (var i = 0; i < attempts; i++) {
-    try {
-      appLog('initFirebaseMessaging: fetching FCM token (attempt $i)');
-      final token = await FirebaseMessaging.instance.getToken();
-      if (token != null) {
-        appLog('FCM token retrieved: $token');
-        return token;
-      }
-    } on FirebaseException catch (e) {
-      if (e.code == 'apns-token-not-set') {
-        await Future.delayed(retryDelay);
-        continue;
-      }
-      appLog('Error getting FCM token: $e');
-      return null;
-    } catch (e) {
-      appLog('Unexpected error getting FCM token: $e');
-      return null;
-    }
-  }
-  appLog('Failed to obtain FCM token after $attempts attempts');
-  return null;
+  final details = NotificationDetails(
+    android: AndroidNotificationDetails(
+      notificationChannel.id,
+      notificationChannel.name,
+      channelDescription: notificationChannel.description,
+      importance: Importance.high,
+    ),
+    iOS: const DarwinNotificationDetails(),
+  );
+
+  await flutterLocalNotificationsPlugin.show(
+    notification.hashCode,
+    notification.title,
+    notification.body,
+    details,
+  );
 }

--- a/lib/features/auth/presentation/manager/cubits/signin_cubit/signin_cubit.dart
+++ b/lib/features/auth/presentation/manager/cubits/signin_cubit/signin_cubit.dart
@@ -113,7 +113,7 @@ class SigninCubit extends SafeCubit<SigninState> with SocialSigninHelper {
     if (Prefs.getBool(key)) return;
 
     appLog('SigninCubit._registerNotifications: requesting FCM token');
-    final token = await initFirebaseMessaging();
+    final token = await getFcmToken();
     if (token == null || token.isEmpty) {
       appLog('SigninCubit._registerNotifications: token unavailable');
       return;

--- a/lib/features/settings/data/repos/settings_repo_impl.dart
+++ b/lib/features/settings/data/repos/settings_repo_impl.dart
@@ -10,7 +10,6 @@ import 'package:deals/core/service/user_service.dart';
 import 'package:deals/features/settings/domain/repos/settings_repo.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:deals/core/utils/firebase_utils.dart';
-import 'package:deals/main.dart'; // for flutterLocalNotificationsPlugin & initializeLocalNotifications()
 
 class SettingsRepoImpl implements SettingsRepo {
   final NotificationsPermissionRepo _notifPermRepo;
@@ -87,9 +86,9 @@ class SettingsRepoImpl implements SettingsRepo {
     try {
       appLog('SettingsRepoImpl.enablePushNotificationsLocal: enabling locally');
       await FirebaseMessaging.instance.setAutoInitEnabled(true);
-      final token = await initFirebaseMessaging();
+      final token = await getFcmToken();
       appLog('New FCM token: $token');
-      await initializeLocalNotifications();
+      await initializeNotifications();
       return const Right(unit);
     } catch (e) {
       appLog('Error enabling push locally: $e');

--- a/lib/features/settings/presentation/manager/settings_cubit.dart
+++ b/lib/features/settings/presentation/manager/settings_cubit.dart
@@ -38,7 +38,7 @@ class SettingsCubit extends SafeCubit<SettingsState>
     if (user == null) return;
 
     appLog('SettingsCubit.togglePush: requesting FCM token');
-    final deviceToken = await initFirebaseMessaging();
+    final deviceToken = await getFcmToken();
     if (deviceToken == null) {
       appLog('SettingsCubit.togglePush: FCM token not available');
       emit(SettingsPushFailure(message: 'FCM token not available'));


### PR DESCRIPTION
## Summary
- handle FCM push notification that launches the app
- set iOS notification presentation options
- log FCM token refresh events
- guard Apple sign-in by clearing stale sessions and validating identity token
- simplify FCM token helper and update permission request flow
- implement Apple sign-in per Firebase docs
- refactor FCM initialization and notification display per docs

## Testing
- `./flutter/bin/flutter analyze` *(fails: see logs)*
- `./flutter/bin/flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6864538ea918832e9c742b4fceac44fc